### PR TITLE
feature: `setup`: enable bash autocompletion

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,8 @@ os_dependencies:
 			tcl-tk   \
 			wget   \
 			docker \
-			copier
+			copier \
+			bash-completion
 
 
 .PHONY: git

--- a/dotfiles/.bash_profile
+++ b/dotfiles/.bash_profile
@@ -7,3 +7,6 @@ eval "$(pyenv init -)"
 
 # Pyenv-virtualenv
 eval "$(pyenv virtualenv-init -)"
+
+# Bash command auto-complete
+[[ -r "$HOMEBREW_REPOSITORY/etc/profile.d/bash_completion.sh" ]] && . "$HOMEBREW_REPOSITORY/etc/profile.d/bash_completion.sh"


### PR DESCRIPTION
# Rationale
Implement bash command autocompletion throughout workspace. This is important to ensure that Makefile targets can be auto-completed at CLI (i.e., using TAB key) so it is easier for developers to create/manage their workspace templates. 

Developer can list all `python*` related subcommands using TAB key:
<img width="725" alt="image" src="https://github.com/user-attachments/assets/75df0325-f89c-491e-a95e-ee269b4ca825" />

# What's in this PR?
- [x] `Makefile`: Add `bash-completion` to core `os_dependencies`
- [x] `dotfiles/.bash_profile`: Run `homebrew/*/bash_completion.sh` script in every new shell terminal, this script is managed by the `bash-completion` package we just installed, and handles pathing so that autocomplete works globally.
> ℹ️ Run `make shell` to rebuild our bash terminal from scratch using `dotfiles` to quickly test changes.

# Citations
1. https://formulae.brew.sh/formula/bash-completion
2. https://stackoverflow.com/a/69010710/10372249